### PR TITLE
Fix loop variable type declaration to ansi spec manner

### DIFF
--- a/binomial.lisp
+++ b/binomial.lisp
@@ -84,8 +84,8 @@ This is the algorithm from Knuth"
      end)
 
     (loop
-       for i integer from 0 to (- n 1)
-       for u = (random-uniform)
+       for i of-type integer from 0 to (- n 1)
+       for u of-type double-float = (random-uniform)
        when (< u p)
        do (incf k))
     k))

--- a/jmt.lisp
+++ b/jmt.lisp
@@ -239,7 +239,6 @@ MT-GENRAND function for clarity."
 (defconstant +mt-tempering-mask-b+ #x9d2c5680)
 (defconstant +mt-tempering-mask-c+ #xefc60000)
 
-
 (defun mt-genrand ()
   (when (>= (mt-random-state-mti *mt-random-state*) +mt-n+)
     (mt-refill))

--- a/jmt.lisp
+++ b/jmt.lisp
@@ -239,6 +239,7 @@ MT-GENRAND function for clarity."
 (defconstant +mt-tempering-mask-b+ #x9d2c5680)
 (defconstant +mt-tempering-mask-c+ #xefc60000)
 
+
 (defun mt-genrand ()
   (when (>= (mt-random-state-mti *mt-random-state*) +mt-n+)
     (mt-refill))

--- a/poisson.lisp
+++ b/poisson.lisp
@@ -61,8 +61,8 @@
   (let ((k 0))
     (declare (type integer k))
     (loop 
-       for m integer = (truncate (* mu (/ 7d0 8d0)))
-       for X double-float = (random-gamma-int m)
+       for m of-type integer = (truncate (* mu (/ 7d0 8d0)))
+       for X of-type double-float = (random-gamma-int m)
        while (> mu 10)
        do (if (>= X mu)
 	      (return-from 


### PR DESCRIPTION
fix for variable type declaration in LOOP that uncomplience ANSI spec

same kissue: https://github.com/lvaruzza/cl-randist/issues/9