### PR TITLE
Optimize JMT and RANDOM-NORMAL for SBCL

### DIFF
--- a/normal.lisp
+++ b/normal.lisp
@@ -221,8 +221,8 @@
         (ktab (load-time-value *ktab* t)))
     (flet ((N01 ()
              (loop
-              (let* ((i (random-mt 256))
-                     (j (random-mt 16777216))
+              (let* ((i (the (integer 0 256) (random-mt 256)))
+                     (j (the (integer 0 16777216) (random-mt 16777216)))
                      ;; -1 if (logbitp 7 i), 1 otherwise
                      (sign (float (- 1 (logandc2 (ash i -6) 1)) 1d0))
                      (i (mod i 128))

--- a/normal.lisp
+++ b/normal.lisp
@@ -221,8 +221,8 @@
         (ktab (load-time-value *ktab* t)))
     (flet ((N01 ()
              (loop
-              (let* ((i (the (integer 0 256) (random-mt 256)))
-                     (j (the (integer 0 16777216) (random-mt 16777216)))
+              (let* ((i (random 256))
+                     (j (random 16777216))
                      ;; -1 if (logbitp 7 i), 1 otherwise
                      (sign (float (- 1 (logandc2 (ash i -6) 1)) 1d0))
                      (i (mod i 128))


### PR DESCRIPTION
I'm using `random-normal` in a tight simulation loop so I optimized its performance.

It gives 6x times speed up on my SBCL 2.1.11:

Before:
```
(time (loop for i below 1000000 sum (cl-randist:random-normal)))
Evaluation took:
0.619 seconds of real time
0.621047 seconds of total run time (0.615463 user, 0.005584 system)
[ Run times consist of 0.019 seconds GC time, and 0.603 seconds non-GC time. ]
100.32% CPU
1,977,362,915 processor cycles
406,634,128 bytes consed

-259.0154850085313d0
```

After:
```
(time (loop for i below 1000000 sum (cl-randist:random-normal)))
Evaluation took:
0.102 seconds of real time
0.102941 seconds of total run time (0.102102 user, 0.000839 system)
[ Run times consist of 0.005 seconds GC time, and 0.098 seconds non-GC time. ]
100.98% CPU
327,808,653 processor cycles
34,340,592 bytes consed

336.72073541129316d0
```

Future idea: RANDOM-NORMAL-ZIGGURAT sometimes uses JMT.LISP, sometimes uses system RANDOM (secretly in the call to RANDOM-POS and RANDOM-UNIFORM). Is it intentional? Would it be better if we consistently use (supposedly faster) JMT.LISP?